### PR TITLE
Comment out logging of the CodePen height value

### DIFF
--- a/src/codepen-nunjucks.js
+++ b/src/codepen-nunjucks.js
@@ -4,7 +4,7 @@ module.exports = (url, {
   height = "300",
   theme = ""
 } = {}) => {
-  console.log(height);
+  // console.log(height);
     const path = new URL(url).pathname;
     const id = path.split('/')[3];
     return `<p class="codepen" data-height="${height}" data-theme-id="${theme}" data-default-tab="${tabs}" data-slug-hash="${id}">


### PR DESCRIPTION
I am seeing "300" being output in the console on every Eleventy build and finally found out why. Not a huge deal but it's not very useful in general. Maybe this should react to Eleventy's quiet/verbose output instead?